### PR TITLE
Update set_up_host.mdx

### DIFF
--- a/docs/getting_start/set_up_host.mdx
+++ b/docs/getting_start/set_up_host.mdx
@@ -35,7 +35,7 @@ resource-pack:
 ## Self-hosting
 
 <UrlCard
-url="set_up_host/self"
+url="self"
 title="Self-hosting"
 subtitle=" "
 />
@@ -43,7 +43,7 @@ subtitle=" "
 ## Lobfile
 
 <UrlCard
-url="set_up_host/lobfile"
+url="lobfile"
 title="Lobfile"
 subtitle=" "
 />
@@ -51,7 +51,7 @@ subtitle=" "
 ## S3
 
 <UrlCard
-url="set_up_host/s3"
+url="s3"
 title="S3"
 subtitle=" "
 />
@@ -65,7 +65,7 @@ The rest are some less common hosting methods. If you need them, feel free to ke
 ## External
 
 <UrlCard
-url="set_up_host/external"
+url="external"
 title="External"
 subtitle=" "
 />
@@ -73,7 +73,7 @@ subtitle=" "
 ## OneDrive
 
 <UrlCard
-url="set_up_host/onedrive"
+url="onedrive"
 title="OneDrive"
 subtitle=" "
 />
@@ -81,7 +81,7 @@ subtitle=" "
 ## Dropbox
 
 <UrlCard
-url="set_up_host/dropbox"
+url="dropbox"
 title="Dropbox"
 subtitle=" "
 />
@@ -89,7 +89,7 @@ subtitle=" "
 ## Alist
 
 <UrlCard
-url="set_up_host/alist"
+url="alist"
 title="Alist"
 subtitle=" "
 />
@@ -97,7 +97,7 @@ subtitle=" "
 ## Gitlab
 
 <UrlCard
-url="set_up_host/gitlab"
+url="gitlab"
 title="Gitlab"
 subtitle=" "
 />


### PR DESCRIPTION
Updated broken links to correct text. Is anyone else able to click the links to each hosting type on the original page [here](https://xiao-momi.github.io/craft-engine-wiki/getting_start/set_up_host/)? They were going to https://xiao-momi.github.io/craft-engine-wiki/getting_start/set_up_host/set_up_host/{insert_host_type_here} previously but now they should link to the correct guides.